### PR TITLE
Fix deploy when database does not exist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 USER node
 
 # copy the dependencies and dists from the builder stage
-COPY --from=pruner /home/node/app /home/node/app/
+COPY --from=pruner --chown=node /home/node/app /home/node/app/
 
 EXPOSE 3000
 

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ run:
 	@echo "Running tabula-rasa..."
 	@docker run --rm --init --name tabula-rasa -p 3000:3000 -m 256m --cpus 0.75 -e NODE_ENV=production -e DATABASE_URL="file:../db/default.db" tabula-rasa:latest-app
 
+shell:
+	@echo "Starting shell in tabula-rasa container..."
+	@docker exec -it tabula-rasa /bin/sh
+
 db-reset:
 	@echo "Resetting the database..."
-	@docker exec -it tabula-rasa npm run db-reset
+	@docker exec -it tabula-rasa npm run db-reset --force

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,6 +2,12 @@
 
 set -e
 
+# shortcut to open shell instead of run app
+if [ "$*" = "shell" ]; then
+  exec /bin/sh
+  exit 0
+fi
+
 # ensure the database is up to date with all migrations
 npm run db-deploy
 


### PR DESCRIPTION
The node user did not have perms to create the db file, due to everything still being owned by the root user.  Now the app files are owned by the node user.