### PR TITLE
fix: generate blog post command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: "Install dependencies"
+          command: "npm install"
+      - run:
           name: "Generate blog post"
           command: "npm run generate-blog-post"
       - run:


### PR DESCRIPTION
Now installing dependencies before running the blog post script in the circleci job.